### PR TITLE
Require user_id

### DIFF
--- a/socks/socks4.py
+++ b/socks/socks4.py
@@ -67,7 +67,7 @@ class SOCKS4Reply(typing.NamedTuple):
 
 
 class SOCKS4Connection:
-    def __init__(self, user_id: bytes = None, allow_domain_names: bool = False):
+    def __init__(self, user_id: bytes, allow_domain_names: bool = False):
         self.user_id = user_id
 
         # Set to 'True' when using 'socks4a://'

--- a/tests/test_socks4.py
+++ b/tests/test_socks4.py
@@ -10,22 +10,7 @@ from socks import (
 
 
 @pytest.mark.parametrize("command", [SOCKS4Command.BIND, SOCKS4Command.CONNECT])
-def test_socks4_connection_request_no_user_id(command: SOCKS4Command) -> None:
-    conn = SOCKS4Connection(user_id=None)
-
-    conn.request(command=command, addr="127.0.0.1", port=8080)
-
-    data = conn.data_to_send()
-    assert len(data) == 9
-    assert data[0:1] == b"\x04"
-    assert data[1:2] == command
-    assert data[2:4] == (8080).to_bytes(2, byteorder="big")
-    assert data[4:8] == b"\x7f\x00\x00\x01"
-    assert data[8] == 0
-
-
-@pytest.mark.parametrize("command", [SOCKS4Command.BIND, SOCKS4Command.CONNECT])
-def test_socks4_connection_request_user_id(command: SOCKS4Command) -> None:
+def test_socks4_connection_request(command: SOCKS4Command) -> None:
     conn = SOCKS4Connection(user_id="socks".encode())
 
     conn.request(command=command, addr="127.0.0.1", port=8080)
@@ -42,7 +27,7 @@ def test_socks4_connection_request_user_id(command: SOCKS4Command) -> None:
 
 @pytest.mark.parametrize("request_reply_code", [value for value in SOCKS4ReplyCode])
 def test_socks4_receive_data(request_reply_code: bytes) -> None:
-    conn = SOCKS4Connection()
+    conn = SOCKS4Connection(user_id=b"socks")
 
     reply = conn.receive_data(
         b"".join(
@@ -69,7 +54,7 @@ def test_socks4_receive_data(request_reply_code: bytes) -> None:
     ],
 )
 def test_socks4_receive_malformed_data(data: bytes) -> None:
-    conn = SOCKS4Connection()
+    conn = SOCKS4Connection(user_id=b"socks")
 
     with pytest.raises(ProtocolError):
         conn.receive_data(data)


### PR DESCRIPTION
The [protocol](https://www.openssh.com/txt/socks4.protocol) defines a user ID is required:

> The client includes in the request packet the IP address and the port number of the destination host, and userid