### PR TITLE
Socks4a

### DIFF
--- a/socks/socks4.py
+++ b/socks/socks4.py
@@ -78,8 +78,10 @@ class SOCKS4Reply(typing.NamedTuple):
 
 
 class SOCKS4Connection:
-    def __init__(self, user_id: bytes):
+    def __init__(self, user_id: bytes, allow_domain_names: bool = False):
         self.user_id = user_id
+        self.allow_domain_names = allow_domain_names
+
         self._data_to_send = bytearray()
         self._received_data = bytearray()
 
@@ -100,6 +102,8 @@ class SOCKS4Connection:
         if address_type == AddressType.IPV6:
             raise SOCKSError("IPv6 addresses not supported by SOCKS4")
         elif address_type == AddressType.DN:
+            if not self.allow_domain_names:
+                raise SOCKSError("Domain names only supported by SOCKS4A")
             RequestCls = SOCKS4ARequest
 
         request = RequestCls(command, port, encoded_addr, user_id)

--- a/tests/test_socks4.py
+++ b/tests/test_socks4.py
@@ -63,7 +63,7 @@ def test_socks4_receive_malformed_data(data: bytes) -> None:
 
 @pytest.mark.parametrize("command", [SOCKS4Command.BIND, SOCKS4Command.CONNECT])
 def test_SOCKS4A_connection_request(command: SOCKS4Command) -> None:
-    conn = SOCKS4Connection(user_id=b"socks")
+    conn = SOCKS4Connection(user_id=b"socks", allow_domain_names=True)
 
     conn.request(command=command, addr="proxy.example.com", port=8080)
 
@@ -75,6 +75,13 @@ def test_SOCKS4A_connection_request(command: SOCKS4Command) -> None:
     assert data[4:8] == b"\x00\x00\x00\xFF"
     assert data[8:14] == b"socks\x00"
     assert data[14:] == b"proxy.example.com\x00"
+
+
+def test_SOCKS4_raises_if_passed_domain_name() -> None:
+    conn = SOCKS4Connection(user_id=b"socks")
+
+    with pytest.raises(SOCKSError):
+        conn.request(command=SOCKS4Command.BIND, addr="proxy.example.com", port=8080)
 
 
 def test_SOCKS4_does_not_support_ipv6() -> None:

--- a/tests/test_socks4.py
+++ b/tests/test_socks4.py
@@ -6,6 +6,7 @@ from socks import (
     SOCKS4Connection,
     SOCKS4Reply,
     SOCKS4ReplyCode,
+    SOCKSError,
 )
 
 
@@ -74,3 +75,10 @@ def test_SOCKS4A_connection_request(command: SOCKS4Command) -> None:
     assert data[4:8] == b"\x00\x00\x00\xFF"
     assert data[8:14] == b"socks\x00"
     assert data[14:] == b"proxy.example.com\x00"
+
+
+def test_SOCKS4_does_not_support_ipv6() -> None:
+    conn = SOCKS4Connection(user_id=b"socks")
+
+    with pytest.raises(SOCKSError):
+        conn.request(command=SOCKS4Command.BIND, addr="0:0:0:0:0:0:0:1", port=8080)

--- a/tests/test_socks4.py
+++ b/tests/test_socks4.py
@@ -58,3 +58,19 @@ def test_socks4_receive_malformed_data(data: bytes) -> None:
 
     with pytest.raises(ProtocolError):
         conn.receive_data(data)
+
+
+@pytest.mark.parametrize("command", [SOCKS4Command.BIND, SOCKS4Command.CONNECT])
+def test_SOCKS4A_connection_request(command: SOCKS4Command) -> None:
+    conn = SOCKS4Connection(user_id=b"socks")
+
+    conn.request(command=command, addr="proxy.example.com", port=8080)
+
+    data = conn.data_to_send()
+    assert len(data) == 32
+    assert data[0:1] == b"\x04"
+    assert data[1:2] == command
+    assert data[2:4] == (8080).to_bytes(2, byteorder="big")
+    assert data[4:8] == b"\x00\x00\x00\xFF"
+    assert data[8:14] == b"socks\x00"
+    assert data[14:] == b"proxy.example.com\x00"


### PR DESCRIPTION
Note I chose to drop `allow_domain_names` and rely on `decode_address` to use either SOCKS4 aor SOCKS4A, let me know we'd rather keep it.